### PR TITLE
Rewrite plugin for Obsidian from Omnivore to InfoFlow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,32 @@
-# obsidian-omnivore
+# obsidian-infoflow
 
-This plugin imports your saved [Omnivore](https://omnivore.app/) articles and highlights into Obsidian.
+This plugin imports your saved InfoFlow articles and highlights into Obsidian.
 
 ## Features
 
 * Import your highlights and saved article
-* Create graphs based on Omnivore data
-* Filter imported data using Omnivores [advanced search syntax](https://docs.omnivore.app/using/search.html)
+* Create graphs based on InfoFlow data
+* Filter imported data using InfoFlow's advanced search syntax
 * Custom templates for imported data
 
 ## Installation
 
 1. Install the plugin from the community or build it from source and load unpacked plugin
-2. Sign up for an [Omnivore account](https://omnivore.app)
-3. Go to [Omnivore](https://omnivore.app/settings/api) and Create an API key
+2. Sign up for an InfoFlow account
+3. Create an API key for InfoFlow
 4. Open settings and add your api key
 
 ## Usage
 
-1. The plugin will sync with Omnivore when you click on Omnivore ribbon icon or use the palette command
-2. You can also change the API key, the search filter, and how often the plugin syncs with Omnivore by updating the settings
-3. The plugin creates a new page for each saved article including metadata, labels. Content you have highlighted in Omnivore, and any notes you added, will be nested in the article page
-4. Clicking on the article will open the Omnivore article in a new tab
+1. The plugin will sync with InfoFlow when you click on InfoFlow ribbon icon or use the palette command
+2. You can also change the API key, the search filter, and how often the plugin syncs with InfoFlow by updating the settings
+3. The plugin creates a new page for each saved article including metadata, labels. Content you have highlighted in InfoFlow, and any notes you added, will be nested in the article page
+4. Clicking on the article will open the InfoFlow article in a new tab
 5. We also create an internal link to each label in the article so you can group articles by label
 
 ## Contacts
 
-[Omnivore](https://github.com/omnivore-app)
+InfoFlow
 
 ## Contributing
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,10 @@
 {
-	"id": "obsidian-omnivore",
-	"name": "Omnivore",
+	"id": "obsidian-infoflow",
+	"name": "InfoFlow",
 	"version": "1.10.4",
 	"minAppVersion": "0.15.0",
-	"description": "This is an Omnivore plugin for Obsidian.",
-	"author": "Omnivore",
+	"description": "This is an InfoFlow plugin for Obsidian.",
+	"author": "InfoFlow",
 	"authorUrl": "https://github.com/omnivore-app",
 	"isDesktopOnly": false
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-	"name": "obsidian-omnivore",
+	"name": "obsidian-infoflow",
 	"version": "1.10.4",
-	"description": "This is an Omnivore plugin for Obsidian.",
+	"description": "This is an InfoFlow plugin for Obsidian.",
 	"main": "main.js",
 	"scripts": {
 		"dev": "node esbuild.config.mjs",
@@ -49,7 +49,6 @@
 		"typescript": "4.7.4"
 	},
 	"dependencies": {
-		"@omnivore-app/api": "^1.0.3",
 		"diff-match-patch": "^1.0.5",
 		"lodash": "^4.17.21",
 		"luxon": "^3.1.1",

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,142 +1,35 @@
-import { Item, ItemFormat, Omnivore } from '@omnivore-app/api'
-import { requestUrl } from 'obsidian'
+import { requestUrl } from 'obsidian';
 
-export enum HighlightColors {
-  Yellow = 'yellow',
-  Red = 'red',
-  Green = 'green',
-  Blue = 'blue',
-}
-
-interface GetContentResponse {
-  data: {
-    libraryItemId: string
-    downloadUrl: string
-    error?: string
-  }[]
-}
-
-const baseUrl = (endpoint: string) => endpoint.replace(/\/api\/graphql$/, '')
-
-const getContent = async (
-  endpoint: string,
-  apiKey: string,
-  libraryItemIds: string[],
-): Promise<GetContentResponse> => {
+export const fetchInfoFlowData = async (apiKey: string, query: string) => {
   const response = await requestUrl({
-    url: `${baseUrl(endpoint)}/api/content`,
+    url: 'https://api.infoflow.com/graphql',
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      Authorization: apiKey,
+      Authorization: `Bearer ${apiKey}`,
     },
-    body: JSON.stringify({ libraryItemIds, format: 'highlightedMarkdown' }),
-  })
+    body: JSON.stringify({ query }),
+  });
 
-  return response.json
-}
-
-const downloadFromUrl = async (url: string): Promise<string> => {
-  try {
-    // polling until download is ready or failed
-    const response = await requestUrl({
-      url,
-    })
-    return response.text
-  } catch (error) {
-    // retry after 1 second if download returns 404
-    if (error.status === 404) {
-      await sleep(1000)
-      return downloadFromUrl(url)
-    }
-
-    throw error
-  }
-}
-
-const fetchContentForItems = async (
-  endpoint: string,
-  apiKey: string,
-  items: Item[],
-) => {
-  const content = await getContent(
-    endpoint,
-    apiKey,
-    items.map((a) => a.id),
-  )
-
-  await Promise.allSettled(
-    content.data.map(async (c) => {
-      if (c.error) {
-        console.error('Error fetching content', c.error)
-        return
-      }
-
-      const item = items.find((i) => i.id === c.libraryItemId)
-      if (!item) {
-        console.error('Item not found', c.libraryItemId)
-        return
-      }
-
-      // timeout if download takes too long
-      item.content = await Promise.race([
-        downloadFromUrl(c.downloadUrl),
-        new Promise<string>(
-          (_, reject) => setTimeout(() => reject('Timeout'), 600_000), // 10 minutes
-        ),
-      ])
-    }),
-  )
-}
-
-export const getItems = async (
-  endpoint: string,
-  apiKey: string,
-  after = 0,
-  first = 10,
-  updatedAt = '',
-  query = '',
-  includeContent = false,
-  format: ItemFormat = 'html',
-): Promise<[Item[], boolean]> => {
-  const omnivore = new Omnivore({
-    authToken: apiKey,
-    baseUrl: baseUrl(endpoint),
-    timeoutMs: 10000, // 10 seconds
-  })
-
-  const response = await omnivore.items.search({
-    after,
-    first,
-    query: `${updatedAt ? 'updated:' + updatedAt : ''} sort:saved-asc ${query}`,
-    includeContent: false,
-    format,
-  })
-
-  const items = response.edges.map((e) => e.node)
-  if (includeContent && items.length > 0) {
-    try {
-      await fetchContentForItems(endpoint, apiKey, items)
-    } catch (error) {
-      console.error('Error fetching content', error)
-    }
+  if (response.status !== 200) {
+    throw new Error(`Error fetching data: ${response.statusText}`);
   }
 
-  return [items, response.pageInfo.hasNextPage]
-}
+  return response.json;
+};
 
-export const deleteItem = async (
-  endpoint: string,
-  apiKey: string,
-  articleId: string,
-) => {
-  const omnivore = new Omnivore({
-    authToken: apiKey,
-    baseUrl: baseUrl(endpoint),
-    timeoutMs: 10000, // 10 seconds
-  })
+export const deleteInfoFlowItem = async (apiKey: string, itemId: string) => {
+  const response = await requestUrl({
+    url: `https://api.infoflow.com/items/${itemId}`,
+    method: 'DELETE',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+    },
+  });
 
-  await omnivore.items.delete({ id: articleId })
+  if (response.status !== 204) {
+    throw new Error(`Error deleting item: ${response.statusText}`);
+  }
 
-  return true
-}
+  return true;
+};

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -7,7 +7,7 @@ export const FRONT_MATTER_VARIABLES = [
   'tags',
   'date_saved',
   'date_published',
-  'omnivore_url',
+  'infoflow_url',
   'site_name',
   'original_url',
   'description',
@@ -35,12 +35,12 @@ export enum HighlightOrder {
 
 export enum HighlightManagerId {
   HIGHLIGHTR = 'hltr',
-  OMNIVORE = 'omni',
+  INFOFLOW = 'info',
 }
 
 export type HighlightColorMapping = { [key in HighlightColors]: string }
 
-export const DEFAULT_SETTINGS: OmnivoreSettings = {
+export const DEFAULT_SETTINGS: InfoFlowSettings = {
   dateHighlightedFormat: 'yyyy-MM-dd HH:mm:ss',
   dateSavedFormat: 'yyyy-MM-dd HH:mm:ss',
   apiKey: '',
@@ -50,12 +50,12 @@ export const DEFAULT_SETTINGS: OmnivoreSettings = {
   template: DEFAULT_TEMPLATE,
   highlightOrder: 'LOCATION',
   syncing: false,
-  folder: 'Omnivore/{{{date}}}',
+  folder: 'InfoFlow/{{{date}}}',
   folderDateFormat: 'yyyy-MM-dd',
-  endpoint: 'https://api-prod.omnivore.app/api/graphql',
+  endpoint: 'https://api.infoflow.com/graphql',
   filename: '{{{title}}}',
   filenameDateFormat: 'yyyy-MM-dd',
-  attachmentFolder: 'Omnivore/attachments',
+  attachmentFolder: 'InfoFlow/attachments',
   version: '0.0.0',
   isSingleFile: false,
   frequency: 0,
@@ -64,7 +64,7 @@ export const DEFAULT_SETTINGS: OmnivoreSettings = {
   frontMatterTemplate: '',
   syncOnStart: true,
   enableHighlightColorRender: false,
-  highlightManagerId: HighlightManagerId.OMNIVORE,
+  highlightManagerId: HighlightManagerId.INFOFLOW,
   highlightColorMapping: {
     [HighlightColors.Yellow]: '#fff3a3',
     [HighlightColors.Red]: '#ff5582',
@@ -73,7 +73,7 @@ export const DEFAULT_SETTINGS: OmnivoreSettings = {
   },
 }
 
-export interface OmnivoreSettings {
+export interface InfoFlowSettings {
   apiKey: string
   filter: string
   syncAt: string

--- a/src/settings/template.ts
+++ b/src/settings/template.ts
@@ -1,4 +1,3 @@
-import { Item, ItemType } from '@omnivore-app/api'
 import { truncate } from 'lodash'
 import Mustache from 'mustache'
 import { parseYaml, stringifyYaml } from 'obsidian'
@@ -21,9 +20,9 @@ type FunctionMap = {
 }
 
 export const DEFAULT_TEMPLATE = `# {{{title}}}
-#Omnivore
+#InfoFlow
 
-[Read on Omnivore]({{{omnivoreUrl}}})
+[Read on InfoFlow]({{{infoFlowUrl}}})
 [Read Original]({{{originalUrl}}})
 
 {{#highlights.length}}
@@ -59,7 +58,7 @@ export type ArticleView =
   | {
       id: string
       title: string
-      omnivoreUrl: string
+      infoFlowUrl: string
       siteName: string
       originalUrl?: string
       author: string
@@ -71,7 +70,7 @@ export type ArticleView =
       fileAttachment?: string
       description?: string
       note?: string
-      type: ItemType
+      type: string
       dateRead?: string
       wordsCount?: number
       readLength?: number
@@ -86,14 +85,14 @@ export type View =
   | {
       id: string
       title: string
-      omnivoreUrl: string
+      infoFlowUrl: string
       siteName: string
       originalUrl: string
       author: string
       date: string
       dateSaved: string
       datePublished?: string
-      type: ItemType
+      type: string
       dateRead?: string
       state: string
       dateArchived?: string
@@ -107,12 +106,12 @@ enum ItemState {
   Archived = 'ARCHIVED',
 }
 
-const getItemState = (item: Item): string => {
+const getItemState = (item: any): string => {
   if (item.isArchived) {
     return ItemState.Archived
   }
-  if (item.readingProgressPercent > 0) {
-    return item.readingProgressPercent === 100
+  if (item.readingProgress > 0) {
+    return item.readingProgress === 100
       ? ItemState.Completed
       : ItemState.Reading
   }
@@ -159,12 +158,12 @@ const functionMap: FunctionMap = {
   formatDate: formatDateFunc,
 }
 
-const getOmnivoreUrl = (item: Item) => {
-  return `https://omnivore.app/me/${item.slug}`
+const getInfoFlowUrl = (item: any) => {
+  return `https://infoflow.com/me/${item.slug}`
 }
 
 export const renderFilename = (
-  item: Item,
+  item: any,
   filename: string,
   dateFormat: string,
 ) => {
@@ -184,7 +183,7 @@ export const renderLabels = (labels?: LabelView[]) => {
 }
 
 export const renderItemContent = async (
-  item: Item,
+  item: any,
   template: string,
   highlightOrder: string,
   highlightManagerId: HighlightManagerId | undefined,
@@ -197,10 +196,10 @@ export const renderItemContent = async (
 ) => {
   // filter out notes and redactions
   const itemHighlights =
-    item.highlights?.filter((h) => h.type === 'HIGHLIGHT') || []
+    item.highlights?.filter((h: any) => h.type === 'HIGHLIGHT') || []
   // sort highlights by location if selected in options
   if (highlightOrder === 'LOCATION') {
-    itemHighlights.sort((a, b) => {
+    itemHighlights.sort((a: any, b: any) => {
       try {
         if (item.pageType === 'FILE') {
           // sort by location in file
@@ -214,7 +213,7 @@ export const renderItemContent = async (
       }
     })
   }
-  const highlights: HighlightView[] = itemHighlights.map((highlight) => {
+  const highlights: HighlightView[] = itemHighlights.map((highlight: any) => {
     const highlightColor = highlight.color ?? 'yellow'
     const highlightRenderOption = highlightManagerId
       ? {
@@ -228,7 +227,7 @@ export const renderItemContent = async (
         template,
         highlightRenderOption,
       ),
-      highlightUrl: `https://omnivore.app/me/${item.slug}#${highlight.id}`,
+      highlightUrl: `https://infoflow.com/me/${item.slug}#${highlight.id}`,
       highlightID: highlight.id.slice(0, 8),
       dateHighlighted: highlight.updatedAt
         ? formatDate(highlight.updatedAt, dateHighlightedFormat)
@@ -249,7 +248,7 @@ export const renderItemContent = async (
   const datePublished = publishedAt
     ? formatDate(publishedAt, dateSavedFormat).trim()
     : undefined
-  const articleNote = item.highlights?.find((h) => h.type === 'NOTE')
+  const articleNote = item.highlights?.find((h: any) => h.type === 'NOTE')
   const dateRead = item.readAt
     ? formatDate(item.readAt, dateSavedFormat).trim()
     : undefined
@@ -260,7 +259,7 @@ export const renderItemContent = async (
   const articleView: ArticleView = {
     id: item.id,
     title: item.title,
-    omnivoreUrl: `https://omnivore.app/me/${item.slug}`,
+    infoFlowUrl: `https://infoflow.com/me/${item.slug}`,
     siteName,
     originalUrl: item.originalArticleUrl || item.url,
     author: item.author || 'unknown',
@@ -308,7 +307,7 @@ export const renderItemContent = async (
       // and add the error to the front matter
       frontMatter = {
         ...frontMatter,
-        omnivore_error:
+        infoFlow_error:
           'There was an error parsing the front matter template. See console for details.',
       }
     }
@@ -360,7 +359,7 @@ export const renderItemContent = async (
   return `${frontMatterStr}\n\n${contentWithoutFrontMatter}`
 }
 
-export const render = (item: Item, template: string, dateFormat: string) => {
+export const render = (item: any, template: string, dateFormat: string) => {
   const dateSaved = formatDate(item.savedAt, dateFormat)
   const datePublished = item.publishedAt
     ? formatDate(item.publishedAt, dateFormat).trim()
@@ -376,7 +375,7 @@ export const render = (item: Item, template: string, dateFormat: string) => {
     siteName:
       item.siteName || siteNameFromUrl(item.originalArticleUrl || item.url),
     author: item.author || 'unknown',
-    omnivoreUrl: getOmnivoreUrl(item),
+    infoFlowUrl: getInfoFlowUrl(item),
     originalUrl: item.originalArticleUrl || item.url,
     date: dateSaved,
     dateSaved,

--- a/src/settingsTab.ts
+++ b/src/settingsTab.ts
@@ -5,7 +5,7 @@ import {
   PluginSettingTab,
   Setting,
 } from 'obsidian'
-import OmnivorePlugin from './main'
+import InfoFlowPlugin from './main'
 import { FolderSuggest } from './settings/file-suggest'
 import {
   DEFAULT_SETTINGS,
@@ -17,10 +17,10 @@ import {
 import { getQueryFromFilter, setOrUpdateHighlightColors } from './util'
 import { HighlightColors } from './api'
 
-export class OmnivoreSettingTab extends PluginSettingTab {
-  plugin: OmnivorePlugin
+export class InfoFlowSettingTab extends PluginSettingTab {
+  plugin: InfoFlowPlugin
 
-  constructor(app: App, plugin: OmnivorePlugin) {
+  constructor(app: App, plugin: InfoFlowPlugin) {
     super(app, plugin)
     this.plugin = plugin
   }
@@ -40,15 +40,15 @@ export class OmnivoreSettingTab extends PluginSettingTab {
           fragment.append(
             'You can create an API key at ',
             fragment.createEl('a', {
-              text: 'https://omnivore.app/settings/api',
-              href: 'https://omnivore.app/settings/api',
+              text: 'https://infoflow.com/settings/api',
+              href: 'https://infoflow.com/settings/api',
             }),
           )
         }),
       )
       .addText((text) =>
         text
-          .setPlaceholder('Enter your Omnivore Api Key')
+          .setPlaceholder('Enter your InfoFlow Api Key')
           .setValue(this.plugin.settings.apiKey)
           .onChange(async (value) => {
             this.plugin.settings.apiKey = value
@@ -64,7 +64,7 @@ export class OmnivoreSettingTab extends PluginSettingTab {
     new Setting(containerEl)
       .setName('Filter')
       .setDesc(
-        "Select an Omnivore search filter type. Changing this would update the 'Custom Query' accordingly and reset the 'Last sync' timestamp",
+        "Select an InfoFlow search filter type. Changing this would update the 'Custom Query' accordingly and reset the 'Last sync' timestamp",
       )
       .addDropdown((dropdown) => {
         dropdown.addOptions(Filter)
@@ -86,8 +86,8 @@ export class OmnivoreSettingTab extends PluginSettingTab {
           fragment.append(
             'See ',
             fragment.createEl('a', {
-              text: 'https://docs.omnivore.app/using/search',
-              href: 'https://docs.omnivore.app/using/search',
+              text: 'https://docs.infoflow.com/using/search',
+              href: 'https://docs.infoflow.com/using/search',
             }),
             " for more info on search query syntax. Changing this would reset the 'Last Sync' timestamp",
           )
@@ -96,7 +96,7 @@ export class OmnivoreSettingTab extends PluginSettingTab {
       .addText((text) =>
         text
           .setPlaceholder(
-            'Enter an Omnivore custom search query if advanced filter is selected',
+            'Enter an InfoFlow custom search query if advanced filter is selected',
           )
           .setValue(this.plugin.settings.customQuery)
           .onChange(async (value) => {
@@ -114,7 +114,7 @@ export class OmnivoreSettingTab extends PluginSettingTab {
     new Setting(containerEl)
       .setName('Sync on startup')
       .setDesc(
-        'Check this box if you want to sync with Omnivore when the app is loaded',
+        'Check this box if you want to sync with InfoFlow when the app is loaded',
       )
       .addToggle((toggle) =>
         toggle
@@ -127,7 +127,7 @@ export class OmnivoreSettingTab extends PluginSettingTab {
     new Setting(containerEl)
       .setName('Frequency')
       .setDesc(
-        'Enter the frequency in minutes to sync with Omnivore automatically. 0 means manual sync',
+        'Enter the frequency in minutes to sync with InfoFlow automatically. 0 means manual sync',
       )
       .addText((text) =>
         text
@@ -151,7 +151,7 @@ export class OmnivoreSettingTab extends PluginSettingTab {
     new Setting(containerEl)
       .setName('Last Sync')
       .setDesc(
-        "Last time the plugin synced with Omnivore. The 'Sync' command fetches articles updated after this timestamp",
+        "Last time the plugin synced with InfoFlow. The 'Sync' command fetches articles updated after this timestamp",
       )
       .addMomentFormat((momentFormat) =>
         momentFormat
@@ -286,7 +286,7 @@ export class OmnivoreSettingTab extends PluginSettingTab {
             'Available metadata can be found at ',
             fragment.createEl('a', {
               text: 'Reference',
-              href: 'https://docs.omnivore.app/integrations/obsidian.html#front-matter',
+              href: 'https://docs.infoflow.com/integrations/obsidian.html#front-matter',
             }),
             fragment.createEl('br'),
             fragment.createEl('br'),
@@ -322,7 +322,7 @@ export class OmnivoreSettingTab extends PluginSettingTab {
             'Enter template to render articles with ',
             fragment.createEl('a', {
               text: 'Reference',
-              href: 'https://docs.omnivore.app/integrations/obsidian.html#controlling-the-layout-of-the-data-imported-to-obsidian',
+              href: 'https://docs.infoflow.com/integrations/obsidian.html#controlling-the-layout-of-the-data-imported-to-obsidian',
             }),
             fragment.createEl('br'),
             fragment.createEl('br'),
@@ -408,7 +408,7 @@ export class OmnivoreSettingTab extends PluginSettingTab {
     new Setting(containerEl)
       .setName('Render Highlight Color')
       .setDesc(
-        'Check this box if you want to render highlights with color used in the Omnivore App',
+        'Check this box if you want to render highlights with color used in the InfoFlow App',
       )
       .addToggle((toggle) =>
         toggle
@@ -451,7 +451,7 @@ export class OmnivoreSettingTab extends PluginSettingTab {
           .onChange(async (value) => {
             this.plugin.settings.highlightManagerId = value
               ? HighlightManagerId.HIGHLIGHTR
-              : HighlightManagerId.OMNIVORE
+              : HighlightManagerId.INFOFLOW
             await this.plugin.saveSettings()
             this.displayBlock(omnivoreHighlightConfigContainer, !value)
           }),
@@ -463,7 +463,7 @@ export class OmnivoreSettingTab extends PluginSettingTab {
       })
     this.displayBlock(
       omnivoreHighlightConfigContainer,
-      this.plugin.settings.highlightManagerId == HighlightManagerId.OMNIVORE,
+      this.plugin.settings.highlightManagerId == HighlightManagerId.INFOFLOW,
     )
     const highlighterSetting = new Setting(omnivoreHighlightConfigContainer)
     const colorPickers: { [color in string]: ColorComponent } = {}
@@ -471,7 +471,7 @@ export class OmnivoreSettingTab extends PluginSettingTab {
     highlighterSetting
       .setName('Configure highlight colors')
       .setDesc(
-        'Configure how the highlight colors in Omnivore should render in notes',
+        'Configure how the highlight colors in InfoFlow should render in notes',
       )
       .addButton((button) => {
         button.setButtonText('Save')
@@ -531,7 +531,7 @@ export class OmnivoreSettingTab extends PluginSettingTab {
 
     new Setting(advancedSettings)
       .setName('API Endpoint')
-      .setDesc("Enter the Omnivore server's API endpoint")
+      .setDesc("Enter the InfoFlow server's API endpoint")
       .addText((text) =>
         text
           .setPlaceholder('API endpoint')
@@ -550,7 +550,7 @@ export class OmnivoreSettingTab extends PluginSettingTab {
             'Enter YAML template to render the front matter with ',
             fragment.createEl('a', {
               text: 'Reference',
-              href: 'https://docs.omnivore.app/integrations/obsidian.html#front-matter-template',
+              href: 'https://docs.infoflow.com/integrations/obsidian.html#front-matter-template',
             }),
             fragment.createEl('br'),
             fragment.createEl('br'),
@@ -588,7 +588,7 @@ export class OmnivoreSettingTab extends PluginSettingTab {
       })
 
     const help = containerEl.createEl('p')
-    help.innerHTML = `For more information, please visit our <a href="https://github.com/omnivore-app/obsidian-omnivore">GitHub page</a>, email us at <a href="mailto:feedback@omnivore.app">feedback@omnivore.app</a> or join our <a href="https://discord.gg/h2z5rppzz9">Discord server</a>.`
+    help.innerHTML = `For more information, please visit our <a href="https://github.com/infoflow-app/obsidian-infoflow">GitHub page</a>, email us at <a href="mailto:feedback@infoflow.com">feedback@infoflow.com</a> or join our <a href="https://discord.gg/h2z5rppzz9">Discord server</a>.`
 
     // script to make collapsible sections
     const coll = document.getElementsByClassName('omnivore-collapsible')

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,40 @@
+export interface Item {
+  id: string;
+  title: string;
+  infoFlowUrl: string;
+  siteName: string;
+  originalUrl?: string;
+  author: string;
+  labels?: LabelView[];
+  dateSaved: string;
+  highlights: HighlightView[];
+  content?: string;
+  datePublished?: string;
+  fileAttachment?: string;
+  description?: string;
+  note?: string;
+  type: string;
+  dateRead?: string;
+  wordsCount?: number;
+  readLength?: number;
+  state: string;
+  dateArchived?: string;
+  image?: string;
+  updatedAt?: string;
+}
+
+export interface LabelView {
+  name: string;
+}
+
+export interface HighlightView {
+  text: string;
+  highlightUrl: string;
+  highlightID: string;
+  dateHighlighted?: string;
+  note?: string;
+  labels?: LabelView[];
+  color: string;
+  positionPercent: number;
+  positionAnchorIndex: number;
+}


### PR DESCRIPTION
Rewrite the plugin for Obsidian from Omnivore to InfoFlow.

* **manifest.json**: Update `id`, `name`, `description`, and `author` fields to refer to InfoFlow.
* **package.json**: Update `name` and `description` fields to refer to InfoFlow. Remove `@omnivore-app/api` dependency.
* **README.md**: Update title, description, installation, usage instructions, and contacts to refer to InfoFlow.
* **src/api.ts**: Remove Omnivore-related functions and imports. Add `fetchInfoFlowData` and `deleteInfoFlowItem` functions for InfoFlow API.
* **src/main.ts**: Update imports, class name, icon ID, settings, and functions to refer to InfoFlow instead of Omnivore.
* **src/settings/index.ts**: Update `DEFAULT_SETTINGS` and `OmnivoreSettings` interface to refer to InfoFlow.
* **src/settings/template.ts**: Update template, functions, and types to refer to InfoFlow data structure.
* **src/settingsTab.ts**: Update settings tab, API key setting description, query options, sync options, article render options, and advanced settings to refer to InfoFlow.
* **src/types.ts**: Add a new `Item` interface for the client side with necessary properties.

